### PR TITLE
fix(centos): replace yum with dnf for modern CentOS

### DIFF
--- a/docker_install.sh
+++ b/docker_install.sh
@@ -185,10 +185,10 @@ update_system() {
             apt-get update -y >> "$LOG_FILE" 2>&1
             apt-get upgrade -y >> "$LOG_FILE" 2>&1
             ;;
-        centos|rhel)
+        rhel)
             yum update -y >> "$LOG_FILE" 2>&1
             ;;
-        fedora)
+        fedora|centos)
             dnf update -y >> "$LOG_FILE" 2>&1
             ;;
         arch)
@@ -212,14 +212,14 @@ install_dependencies() {
                 lsb-release \
                 software-properties-common >> "$LOG_FILE" 2>&1
             ;;
-        centos|rhel)
+        rhel)
             yum install -y \
                 yum-utils \
                 device-mapper-persistent-data \
                 lvm2 \
                 curl >> "$LOG_FILE" 2>&1
             ;;
-        fedora)
+        fedora|centos)
             dnf install -y \
                 dnf-plugins-core \
                 curl >> "$LOG_FILE" 2>&1
@@ -243,11 +243,14 @@ add_docker_repo() {
             echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/$DISTRO $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
             apt-get update >> "$LOG_FILE" 2>&1
             ;;
-        centos|rhel)
+        rhel)
             yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo >> "$LOG_FILE" 2>&1
             ;;
         fedora)
             dnf-3 config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo >> "$LOG_FILE" 2>&1
+            ;;
+        centos)
+            dnf-3 config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo >> "$LOG_FILE" 2>&1
             ;;
         arch)
             # TODO

--- a/docker_install.sh
+++ b/docker_install.sh
@@ -267,12 +267,11 @@ install_docker() {
         ubuntu|debian)
             apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin >> "$LOG_FILE" 2>&1
             ;;
-        centos|rhel|fedora)
-            if [[ $DISTRO == "fedora" ]]; then
-                dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin >> "$LOG_FILE" 2>&1
-            else
-                yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin >> "$LOG_FILE" 2>&1
-            fi
+        centos|fedora)
+            dnf install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin >> "$LOG_FILE" 2>&1
+            ;;
+        rhel)
+            yum install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin >> "$LOG_FILE" 2>&1
             ;;
         arch)
             pacman -S --noconfirm docker docker-compose >> "$LOG_FILE" 2>&1
@@ -290,12 +289,11 @@ install_docker_compose() {
             ubuntu|debian)
                 apt-get install -y docker-compose-plugin >> "$LOG_FILE" 2>&1
                 ;;
-            centos|rhel|fedora)
-                if [[ $DISTRO == "fedora" ]]; then
-                    dnf install -y docker-compose-plugin >> "$LOG_FILE" 2>&1
-                else
-                    yum install -y docker-compose-plugin >> "$LOG_FILE" 2>&1
-                fi
+            centos|fedora)
+                dnf install -y docker-compose-plugin >> "$LOG_FILE" 2>&1
+                ;;
+            rhel)
+                yum install -y docker-compose-plugin >> "$LOG_FILE" 2>&1
                 ;;
         esac
         


### PR DESCRIPTION
This PR updates the Docker installation script to use dnf for CentOS, replacing the outdated use of yum. wich prevented the script from working correctly on modern CentOS systems.

**Details:**
- _yum_ was officially replaced by _dnf_ in CentOS 8 (September 2019), 6 years ago. It’s reasonable to assume new users will require dnf more that yum.

- Simplified conditional logic for distribution detection, improving readability and maintainability.

**Friendly note:**
Please consider merging this PR instead of removing the repository, this helps keep improvements collaborative and transparent.